### PR TITLE
note limitations of imagery tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Feel free to open an issue if you see cases where the regex is not working corre
 
 ### Imagery Software
 
-One optional tag for changesets is the imagery tag, which is used to add an image source if aerial or other imagery is used. 
+One optional tag for changesets is the `imagery` tag, which is used by some editors to add an image source if aerial or other imagery is used. 
 It's necessary to filter the tag to get an overview of the most common image sources.
 The filtering is done with `if` statements and can be reviewed at [src/save_changesets_csv.py](src/save_changesets_csv.py).
 Feel free to open an issue if the filter is not working as intended.
+
+Note that `imagery` tag is set by iD, Vespucci and Go Map!! and is not set by JOSM.
 
 ### Cooperations
 


### PR DESCRIPTION
related to #6 (I would remove "How popular are imagery services" graph as it is simply graph of iD use, but this note applies also to other graphs that are more useful, even if they are not processing JOSM data)