### PR TITLE
fix bug for created_by_top_10_contributor_count_first_changeset_monthly

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -502,7 +502,7 @@ def save_tag_top_10_contributor_count_first_changeset_monthly(
     indices = [tag_to_index[tag_name] for tag_name in names]
 
     contibutor_monthly = (
-        ddf[ddf[tag].isin(indices)].groupby(["user_index"], observed=False)["month_index", tag].first().compute()
+        ddf.groupby(["user_index"], observed=False)["month_index", tag].first().compute()
     )
     contibutor_count_monthly = (
         contibutor_monthly.reset_index().groupby(["month_index", tag], observed=False)["user_index"].count()


### PR DESCRIPTION
This was a bug. The script was only looking at all changeset from the top 100 editors to determine the first used editor. If someone would have used an editor not in the top 100 and then use one from the top 100, it would have counted as "the first editor". This is now fixed.