### PR TITLE
Fixing an always empty ends_with_list

### DIFF
--- a/src/changeset_to_parquet.py
+++ b/src/changeset_to_parquet.py
@@ -240,7 +240,7 @@ def create_replace_rules():
                     [(len(starts_with), starts_with, name) for starts_with in name_infos["starts_with"]],
                 )
             if "ends_with" in name_infos:
-                starts_with_list.extend(
+                ends_with_list.extend(
                     [(len(ends_with), ends_with, name) for ends_with in name_infos["ends_with"]],
                 )
             if "contains" in name_infos:


### PR DESCRIPTION
Thank you for `replace_rules_created_by.json`. While studying your parser, I noticed that there is an error where the `ends_with` rules are not taken into account.

Because of this, the statistics are displayed separately `https://osm.wikidata.link/` and `https://map.osm.wikidata.link/` https://piebro.github.io/openstreetmap-statistics/#c229

I didn't check the correctness of this PR by running the script, but it seems like it should work.