### PR TITLE
Added CoMaps to editor list

### DIFF
--- a/src/replace_rules_created_by.json
+++ b/src/replace_rules_created_by.json
@@ -99,6 +99,13 @@
             "CODAP "
         ]
     },
+    "CoMaps": {
+        "link": "https://www.comaps.app/",
+        "starts_with": [
+            "CoMaps "
+        ],
+        "type": "mobile_editor"
+    },
     "Completionist": {
         "starts_with": [
             "Completionist "


### PR DESCRIPTION
Adds [CoMaps](https://www.comaps.app/), the community fork of Organic Maps.
Example changeset: https://www.openstreetmap.org/changeset/167232680

I added both Android and iOS as one entry (I personally think that splitting into two entries doesn't really make sense). But i can also change it to two entries to be more consistent with other apps in the list.