### PR TITLE
Updated two links

### DIFF
--- a/src/replace_rules_created_by.json
+++ b/src/replace_rules_created_by.json
@@ -311,7 +311,7 @@
         ]
     },
     "Map builder": {
-        "link": "https://www.bing.com/mapbuilder/",
+        "link": "https://wiki.openstreetmap.org/wiki/Map_builder",
         "starts_with": [
             "Map builder "
         ],
@@ -323,7 +323,7 @@
         ]
     },
     "MapComplete": {
-        "link": "https://mapcomplete.osm.be",
+        "link": "https://mapcomplete.org",
         "starts_with": [
             "MapComplete "
         ],


### PR DESCRIPTION
- Linked Map Builder to the Wiki as https://www.bing.com/mapbuilder/ is not available any more
- Updated MapComplete link because https://mapcomplete.osm.be redirects to https://mapcomplete.org