### PR TITLE
change editor type of JOSM to desktop_editor

### DIFF
--- a/config/replace_rules_created_by.json
+++ b/config/replace_rules_created_by.json
@@ -262,7 +262,7 @@
             "josm"
 
         ],
-        "type": "tool"
+        "type": "desktop_editor"
     },
     "Jungle Bus": {
         "starts_with": [


### PR DESCRIPTION
Changed the editor type of JOSM because the editor is mostly used as a `desktop_editor` and not as a `tool` for automated edits.

The current classification as a `tool` distorts the _Monthly Contributors / Edit count by Device Type_ graphs and gives the wrong impression that most of the edits on OSM would be done by automated scripts/tools.

<img width="2370" height="900" alt="grafik" src="https://github.com/user-attachments/assets/e006529a-283c-408b-b386-a5eae44cc833" />
