### PR TITLE
add better-osm-org into editors list

### DIFF
--- a/config/replace_rules_created_by.json
+++ b/config/replace_rules_created_by.json
@@ -35,6 +35,13 @@
     "bash script": {
         "type": "tool"
     },
+    "better osm.org": {
+        "link": "https://github.com/deevroman/better-osm-org",
+        "starts_with": [
+            "better osm.org"
+        ],
+        "type": "desktop_editor"
+    },
     "Brick": {
         "link": "https://github.com/OSMBuildings/Brick"
     },


### PR DESCRIPTION
This is my script, which gradually introduces new features for editing objects, so I would like to add it to this list.

Examples of changesets:

https://osm.org/changeset/162906299
https://osm.org/changeset/177116911