### PR TITLE
Add DeFlock editor

### DIFF
--- a/config/replace_rules_created_by.json
+++ b/config/replace_rules_created_by.json
@@ -148,6 +148,13 @@
             "DataNovaImportScripts "
         ]
     },
+    "DeFlock": {
+        "link": "https://wiki.openstreetmap.org/wiki/Deflock",
+        "starts_with": [
+            "DeFlock "
+        ],
+        "type": "mobile_editor"
+    },
     "Deriviste": {
         "type": "desktop_editor"
     },


### PR DESCRIPTION
DeFlock is an OSM editor that became popular pretty fast. The most used version (DeFlock 2.10.1) had 4,399 users in January to May this year.

OSM Wiki: https://wiki.openstreetmap.org/wiki/Deflock